### PR TITLE
Update Paystack API wrapper

### DIFF
--- a/.changeset/curly-bulldogs-argue.md
+++ b/.changeset/curly-bulldogs-argue.md
@@ -1,0 +1,7 @@
+---
+"medusa-payment-paystack": patch
+---
+
+Removes outdated Paystack API wrapper package we were using prior fixing deprecated dependency warnings.
+
+Also changes how we generate references. Transactions are initialized with Paystack and the returned reference used instead of an arbitrary cuid.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - [Paystack account](https://dashboard.paystack.com/#/signup)
 - [Paystack account's secret key](https://support.paystack.com/hc/en-us/articles/360009881600-Paystack-Test-Keys-Live-Keys-and-Webhooks)
-- Medusa server running at least `@medusajs/medusa^1.5.0`
+- Medusa server
 
 ## Medusa Server
 
@@ -67,15 +67,13 @@ Using this returned reference as the Paystack transaction's reference allows the
 
 ### Using Transaction Reference
 
-`medusa-payment-paystack` inserts a `paystackTxRef` into the [`PaymentSession`](https://docs.medusajs.com/advanced/backend/payment/overview/#payment-session)'s data.
+`medusa-payment-paystack` inserts a reference named `paystackTxRef` into the [`PaymentSession`](https://docs.medusajs.com/advanced/backend/payment/overview/#payment-session)'s data.
 
 ```
 const { paystackTxRef } = paymentSession.data
 ```
 
-Provide this reference when initiating any of the Paystack [Accept Payment](https://paystack.com/docs/payments/accept-payments/) flows.
-
-For example, when using the [Paystack Popup](https://paystack.com/docs/payments/accept-payments/#popup), provide this reference to the initialization method;
+Provide this reference when initiating the Paystack [Popup](https://paystack.com/docs/payments/accept-payments/#popup) payment flow.
 
 ```js
 const paymentForm = document.getElementById('paymentForm');

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -13,9 +13,7 @@
     "@medusajs/medusa": "^1.13.0"
   },
   "dependencies": {
-    "@medusajs/utils": "^1.9.4",
-    "@paralleldrive/cuid2": "^2.2.1",
-    "paystack-api": "^2.0.6"
+    "@medusajs/utils": "^1.9.4"
   },
   "devDependencies": {
     "@medusajs/medusa": "^1.13.0",

--- a/packages/plugin/src/lib/__mocks__/paystack.ts
+++ b/packages/plugin/src/lib/__mocks__/paystack.ts
@@ -20,8 +20,9 @@ export const PaystackProviderServiceMock = {
           });
         case "123-false":
           return Promise.resolve({
+            status: false,
             data: {
-              status: false,
+              status: "failed",
               id: "123",
             },
           });
@@ -37,6 +38,15 @@ export const PaystackProviderServiceMock = {
       }
     }),
 
+    initialize: jest.fn().mockImplementation(({ amount, email }) => {
+      return Promise.resolve({
+        data: {
+          reference: "ref-" + Math.random() * 1000,
+          authorization_url: "https://paystack.com/123",
+        },
+      });
+    }),
+
     get: jest.fn().mockImplementation(({ id }) => {
       switch (id) {
         case "123-success":
@@ -50,8 +60,9 @@ export const PaystackProviderServiceMock = {
 
         case "123-false":
           return Promise.resolve({
+            status: false,
             data: {
-              status: false,
+              status: "failed",
               paystackTxId: id,
               paystackTxData: {},
             },
@@ -80,6 +91,4 @@ export const PaystackProviderServiceMock = {
   },
 };
 
-const paystackapi = jest.fn(() => PaystackProviderServiceMock);
-
-export default paystackapi;
+export default jest.fn(() => PaystackProviderServiceMock);

--- a/packages/plugin/src/lib/paystack.ts
+++ b/packages/plugin/src/lib/paystack.ts
@@ -13,6 +13,12 @@ type HTTPMethod =
   | "OPTIONS"
   | "HEAD";
 
+type PaystackResponse<T> = {
+  status: boolean;
+  message: string;
+  data: T;
+};
+
 interface Request {
   path: string;
   method: HTTPMethod;
@@ -20,12 +26,6 @@ interface Request {
   body?: Record<string, unknown>;
   query?: Record<string, string>;
 }
-
-type PaystackResponse<T> = {
-  status: boolean;
-  message: string;
-  data: T;
-};
 
 export interface PaystackTransactionAuthorisation {
   reference: string;
@@ -65,9 +65,7 @@ export default class Paystack {
 
         res.on("end", () => {
           try {
-            const response = JSON.parse(Buffer.concat(data).toString()) as T;
-
-            resolve(response as T);
+            resolve(JSON.parse(Buffer.concat(data).toString()) as T);
           } catch (e) {
             reject(e);
           }

--- a/packages/plugin/src/lib/paystack.ts
+++ b/packages/plugin/src/lib/paystack.ts
@@ -1,0 +1,165 @@
+import https from "https";
+
+import { SupportedCurrency } from "../utils/currencyCode";
+
+const PAYSTACK_API_PATH = "https://api.paystack.co";
+
+type HTTPMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "OPTIONS"
+  | "HEAD";
+
+interface Request {
+  path: string;
+  method: HTTPMethod;
+  headers?: Record<string, string>;
+  body?: Record<string, unknown>;
+  query?: Record<string, string>;
+}
+
+type PaystackResponse<T> = {
+  status: boolean;
+  message: string;
+  data: T;
+};
+
+export interface PaystackTransactionAuthorisation {
+  reference: string;
+  authorization_url: string;
+  access_code: string;
+}
+
+export default class Paystack {
+  apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  protected async requestPaystackAPI<T>(request: Request): Promise<T> {
+    const path =
+      request.path.replace(/\/$/, "") +
+      "/?" +
+      new URLSearchParams(request.query).toString();
+
+    const options = {
+      method: request.method,
+      path,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+    };
+
+    return new Promise((resolve, reject) => {
+      const req = https.request(PAYSTACK_API_PATH, options, res => {
+        let data: Uint8Array[] = [];
+
+        res.on("data", chunk => {
+          data.push(chunk);
+        });
+
+        res.on("end", () => {
+          try {
+            const response = JSON.parse(Buffer.concat(data).toString()) as T;
+
+            resolve(response as T);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+
+      req.on("error", e => {
+        reject(e);
+      });
+
+      if (request.body && Object.values(request.body).length > 0) {
+        req.write(JSON.stringify(request.body));
+      }
+
+      req.end();
+    });
+  }
+
+  transaction = {
+    verify: ({ reference }: { reference: string }) =>
+      this.requestPaystackAPI<
+        PaystackResponse<{
+          id: number;
+          status: string;
+          reference: string;
+        }>
+      >({
+        path: "/transaction/verify/" + reference,
+        method: "GET",
+      }),
+    get: ({ id }: { id: string }) =>
+      this.requestPaystackAPI<
+        PaystackResponse<{
+          id: number;
+          status: string;
+          reference: string;
+        }>
+      >({
+        path: "/transaction/" + id,
+        method: "GET",
+      }),
+    initialize: ({
+      amount,
+      email,
+      currency,
+      reference,
+    }: {
+      amount: number;
+      email?: string;
+      currency?: SupportedCurrency;
+      reference?: string;
+    }) =>
+      this.requestPaystackAPI<
+        PaystackResponse<{
+          authorization_url: string;
+          access_code: string;
+          reference: string;
+        }>
+      >({
+        path: "/transaction/initialize",
+        method: "POST",
+        body: {
+          amount,
+          email,
+          currency,
+          reference,
+        },
+      }),
+  };
+
+  refund = {
+    create: ({
+      transaction,
+      amount,
+    }: {
+      transaction: string;
+      amount: number;
+    }) =>
+      this.requestPaystackAPI<
+        PaystackResponse<{
+          id: number;
+          status: string;
+          reference: string;
+          amount: number;
+        }>
+      >({
+        path: "/refund",
+        method: "POST",
+        body: {
+          transaction,
+          amount,
+        },
+      }),
+  };
+}

--- a/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
@@ -191,7 +191,20 @@ describe("retrievePayment", () => {
 });
 
 describe("updatePaymentData", () => {
-  it("errors out if we try to update the amount", async () => {});
+  it("errors out if we try to update the amount", async () => {
+    expect.assertions(1);
+    const service = createPaystackProviderService();
+
+    try {
+      await service.updatePaymentData("1", {
+        amount: 100,
+      });
+    } catch (error) {
+      expect(error.message).toEqual(
+        "Cannot update amount from updatePaymentData",
+      );
+    }
+  });
 
   it("returns the same payment data object", async () => {
     const service = createPaystackProviderService();

--- a/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
@@ -1,4 +1,3 @@
-import { isCuid } from "@paralleldrive/cuid2";
 import PaystackPaymentProcessor from "../paystack-payment-processor";
 import {
   PaymentProcessorContext,
@@ -37,12 +36,14 @@ function checkForPaymentProcessorError<T>(response: T | PaymentProcessorError) {
 
 const demoSessionContext = {
   amount: 100,
-  currency_code: "ghc",
+  currency_code: "GHS",
   email: "andrew@a11rew.dev",
   resource_id: "123",
   context: {},
   paymentSessionData: {},
 } satisfies PaymentProcessorContext;
+
+jest.mock("../../lib/paystack");
 
 describe("Provider Service Initialization", () => {
   it("initializes the provider service", () => {
@@ -64,20 +65,12 @@ describe("createPayment", () => {
     const service = createPaystackProviderService();
     const {
       session_data: { paystackTxRef },
-    } = checkForPaymentProcessorError(await service.initiatePayment());
+    } = checkForPaymentProcessorError(
+      await service.initiatePayment(demoSessionContext),
+    );
 
     expect(paystackTxRef).toBeTruthy();
     expect(paystackTxRef).toEqual(expect.any(String));
-  });
-
-  it("returns a valid cuid as reference", async () => {
-    const service = createPaystackProviderService();
-    const {
-      session_data: { paystackTxRef },
-    } = checkForPaymentProcessorError(await service.initiatePayment());
-
-    expect(paystackTxRef).toEqual(expect.any(String));
-    expect(isCuid(paystackTxRef)).toBeTruthy();
   });
 });
 
@@ -86,7 +79,9 @@ describe("updatePayment", () => {
     const service = createPaystackProviderService();
     const {
       session_data: { paystackTxRef: oldRef },
-    } = checkForPaymentProcessorError(await service.initiatePayment());
+    } = checkForPaymentProcessorError(
+      await service.initiatePayment(demoSessionContext),
+    );
 
     const {
       session_data: { paystackTxRef: newRef },
@@ -95,10 +90,6 @@ describe("updatePayment", () => {
         ...demoSessionContext,
       }),
     );
-
-    // Both refs should be valid cuids
-    expect(isCuid(oldRef)).toBeTruthy();
-    expect(isCuid(newRef)).toBeTruthy();
 
     // The refs should be different
     expect(oldRef).not.toEqual(newRef);
@@ -109,14 +100,9 @@ describe("Authorize Payment", () => {
   it("returns status error on Paystack tx authorization fail", async () => {
     const service = createPaystackProviderService();
     const payment = checkForPaymentProcessorError(
-      await service.authorizePayment(
-        {
-          paystackTxRef: "123-failed",
-        },
-        {
-          cart_id: "123",
-        },
-      ),
+      await service.authorizePayment({
+        paystackTxRef: "123-failed",
+      }),
     );
     expect(payment.status).toEqual(PaymentSessionStatus.ERROR);
   });
@@ -125,14 +111,9 @@ describe("Authorize Payment", () => {
     const service = createPaystackProviderService();
 
     const payment = checkForPaymentProcessorError(
-      await service.authorizePayment(
-        {
-          paystackTxRef: "123-passed",
-        },
-        {
-          cart_id: "123",
-        },
-      ),
+      await service.authorizePayment({
+        paystackTxRef: "123-passed",
+      }),
     );
 
     expect(payment.status).toEqual(PaymentSessionStatus.AUTHORIZED);
@@ -141,14 +122,9 @@ describe("Authorize Payment", () => {
   it("returns status error on Paystack invalid key error", async () => {
     const service = createPaystackProviderService();
     const payment = checkForPaymentProcessorError(
-      await service.authorizePayment(
-        {
-          paystackTxRef: "123-false",
-        },
-        {
-          cart_id: "123",
-        },
-      ),
+      await service.authorizePayment({
+        paystackTxRef: "123-false",
+      }),
     );
 
     expect(payment.status).toEqual(PaymentSessionStatus.ERROR);
@@ -158,14 +134,9 @@ describe("Authorize Payment", () => {
     // Never happens in practice, but just in case
     const service = createPaystackProviderService();
     const payment = checkForPaymentProcessorError(
-      await service.authorizePayment(
-        {
-          paystackTxRef: "123-pending",
-        },
-        {
-          cart_id: "123",
-        },
-      ),
+      await service.authorizePayment({
+        paystackTxRef: "123-pending",
+      }),
     );
 
     expect(payment.status).toEqual(PaymentSessionStatus.PENDING);
@@ -220,7 +191,9 @@ describe("retrievePayment", () => {
 });
 
 describe("updatePaymentData", () => {
-  it("returns an updated payment data object", async () => {
+  it("errors out if we try to update the amount", async () => {});
+
+  it("returns the same payment data object", async () => {
     const service = createPaystackProviderService();
     const existingRef = "123-pending";
     const payment = checkForPaymentProcessorError(
@@ -229,11 +202,14 @@ describe("updatePaymentData", () => {
       }),
     );
 
-    // The ref should be different
-    expect(payment.session_data.paystackTxRef).not.toEqual(existingRef);
-
-    // The ref should be a valid cuid
-    expect(isCuid(payment.session_data.paystackTxRef)).toBeTruthy();
+    // The ref should be the same
+    expect(
+      (
+        payment.session_data as {
+          paystackTxRef: string;
+        }
+      )?.paystackTxRef,
+    ).toEqual(existingRef);
   });
 });
 

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -1,5 +1,7 @@
-import Paystack from "paystack-api";
-import { createId } from "@paralleldrive/cuid2";
+// import { Paystack } from "@paystack/paystack-sdk";
+// import type { Transaction } from "@paystack/paystack-sdk/lib/types/apis/Transaction";
+
+import Paystack, { PaystackTransactionAuthorisation } from "../lib/paystack";
 
 import {
   AbstractPaymentProcessor,
@@ -9,7 +11,8 @@ import {
   PaymentSessionStatus,
   MedusaContainer,
 } from "@medusajs/medusa";
-import { MedusaError } from "@medusajs/utils";
+import { MedusaError, MedusaErrorTypes } from "@medusajs/utils";
+import { validateCurrencyCode } from "../utils/currencyCode";
 
 export interface PaystackPaymentProcessorConfig {
   /**
@@ -54,19 +57,36 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
   /**
    * Called when a user selects Paystack as their payment method during checkout
    */
-  async initiatePayment(): Promise<
+  async initiatePayment(context: PaymentProcessorContext): Promise<
     | PaymentProcessorError
     | (PaymentProcessorSessionResponse & {
         session_data: {
           paystackTxRef: string;
+          paystackTxAuthData: PaystackTransactionAuthorisation;
         };
       })
   > {
-    const reference = createId();
+    const { amount, email, currency_code } = context;
+
+    const validatedCurrencyCode = validateCurrencyCode(currency_code);
+
+    const { data, status, message } =
+      await this.paystack.transaction.initialize({
+        amount,
+        email,
+        currency: validatedCurrencyCode,
+      });
+
+    if (status === false) {
+      return this.buildError("Failed to initiate Paystack payment", {
+        detail: message,
+      });
+    }
 
     return {
       session_data: {
-        paystackTxRef: reference,
+        paystackTxRef: data.reference,
+        paystackTxAuthData: data,
       },
     };
   }
@@ -76,22 +96,21 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
    * We build a new reference here to ensure that the user is not charged twice
    */
   async updatePaymentData(
-    sessionId: string,
+    _: string,
     data: Record<string, unknown>,
   ): Promise<
-    | {
-        session_data: {
-          paystackTxRef: string;
-        };
-      }
-    | PaymentProcessorError
+    PaymentProcessorSessionResponse["session_data"] | PaymentProcessorError
   > {
-    const reference = createId();
+    if (data.amount) {
+      throw new MedusaError(
+        MedusaErrorTypes.INVALID_DATA,
+        "Cannot update amount from updatePaymentData",
+      );
+    }
 
     return {
       session_data: {
-        ...data, // We return the previous data as well
-        paystackTxRef: reference,
+        ...data, // We just return the data as is
       },
     };
   }
@@ -107,14 +126,8 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
         };
       })
   > {
-    const reference = createId();
-
-    return {
-      ...context,
-      session_data: {
-        paystackTxRef: reference,
-      },
-    };
+    // Re-initialize the payment
+    return this.initiatePayment(context);
   }
 
   /**
@@ -123,9 +136,6 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
    */
   async authorizePayment(
     paymentSessionData: Record<string, unknown> & { paystackTxRef: string },
-    context: {
-      cart_id: string;
-    },
   ): Promise<
     | PaymentProcessorError
     | {
@@ -136,9 +146,21 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
     try {
       const { paystackTxRef } = paymentSessionData;
 
-      const { data } = await this.paystack.transaction.verify({
+      const { status, data } = await this.paystack.transaction.verify({
         reference: paystackTxRef,
       });
+
+      if (status === false) {
+        // Invalid key error
+        return {
+          status: PaymentSessionStatus.ERROR,
+          data: {
+            ...paymentSessionData,
+            paystackTxId: null,
+            paystackTxData: data,
+          },
+        };
+      }
 
       switch (data.status) {
         case "success": {
@@ -163,16 +185,6 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
             },
           };
 
-        case false:
-          // Invalid key error
-          return {
-            status: PaymentSessionStatus.ERROR,
-            data: {
-              ...paymentSessionData,
-              paystackTxId: null,
-              paystackTxData: data,
-            },
-          };
         default:
           // Pending transaction
           return {
@@ -181,7 +193,7 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
           };
       }
     } catch (error) {
-      return this.buildError("Error authorizing payment", error);
+      return this.buildError("Failed to authorize payment", error);
     }
   }
 
@@ -194,16 +206,22 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
     try {
       const { paystackTxId } = paymentSessionData;
 
-      const { data } = await this.paystack.transaction.get({
+      const { data, status, message } = await this.paystack.transaction.get({
         id: paystackTxId,
       });
+
+      if (status === false) {
+        return this.buildError("Failed to retrieve payment", {
+          detail: message,
+        });
+      }
 
       return {
         ...paymentSessionData,
         paystackTxData: data,
       };
     } catch (error) {
-      return this.buildError("Error retrieving payment", error);
+      return this.buildError("Failed to retrieve payment", error);
     }
   }
 
@@ -211,23 +229,29 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
    * Refunds payment for Paystack transaction
    */
   async refundPayment(
-    paymentSessionData: Record<string, unknown>,
+    paymentSessionData: Record<string, string>,
     refundAmount: number,
   ): Promise<Record<string, unknown> | PaymentProcessorError> {
     try {
       const { paystackTxId } = paymentSessionData;
 
-      const { data } = await this.paystack.refund.create({
+      const { data, status, message } = await this.paystack.refund.create({
         transaction: paystackTxId,
         amount: refundAmount,
       });
+
+      if (status === false) {
+        return this.buildError("Failed to refund payment", {
+          detail: message,
+        });
+      }
 
       return {
         ...paymentSessionData,
         paystackTxData: data,
       };
     } catch (error) {
-      return this.buildError("Error refunding payment", error);
+      return this.buildError("Failed to refund payment", error);
     }
   }
 
@@ -244,16 +268,18 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
     }
 
     try {
-      const { data } = await this.paystack.transaction.get({
+      const { data, status } = await this.paystack.transaction.get({
         id: paystackTxId,
       });
+
+      if (status === false) {
+        return PaymentSessionStatus.ERROR;
+      }
 
       switch (data?.status) {
         case "success":
           return PaymentSessionStatus.AUTHORIZED;
         case "failed":
-          return PaymentSessionStatus.ERROR;
-        case false:
           return PaymentSessionStatus.ERROR;
         default:
           return PaymentSessionStatus.PENDING;
@@ -296,14 +322,14 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
     message: string,
     e:
       | {
-          code: string;
+          code?: string;
           detail: string;
         }
       | Error,
   ): PaymentProcessorError {
     return {
-      error: message,
-      code: "code" in e ? e.code : "",
+      error: "Paystack Payment error: " + message,
+      code: "code" in e ? e.code : "PAYSTACK_PAYMENT_ERROR",
       detail: "detail" in e ? e.detail : e.message ?? "",
     };
   }

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -90,7 +90,6 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
 
   /**
    * Called when a user updates their cart after `initiatePayment` has been called
-   * We build a new reference here to ensure that the user is not charged twice
    */
   async updatePaymentData(
     _: string,

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -1,6 +1,3 @@
-// import { Paystack } from "@paystack/paystack-sdk";
-// import type { Transaction } from "@paystack/paystack-sdk/lib/types/apis/Transaction";
-
 import Paystack, { PaystackTransactionAuthorisation } from "../lib/paystack";
 
 import {

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -72,7 +72,7 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
 
     const { data, status, message } =
       await this.paystack.transaction.initialize({
-        amount,
+        amount: amount * 100, // Paystack expects amount in lowest denomination - https://paystack.com/docs/payments/accept-payments/#initialize-transaction-1
         email,
         currency: validatedCurrencyCode,
       });
@@ -163,7 +163,7 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
       }
 
       switch (data.status) {
-        case "success": {
+        case "success":
           // Successful transaction
           return {
             status: PaymentSessionStatus.AUTHORIZED,
@@ -172,7 +172,6 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
               paystackTxData: data,
             },
           };
-        }
 
         case "failed":
           // Failed transaction

--- a/packages/plugin/src/utils/currencyCode.ts
+++ b/packages/plugin/src/utils/currencyCode.ts
@@ -1,0 +1,27 @@
+import { MedusaError, MedusaErrorTypes } from "@medusajs/utils";
+
+export const supportedCurrencies = ["NGN", "GHS", "ZAR", "USD"] as const;
+
+export type SupportedCurrency = (typeof supportedCurrencies)[number];
+
+export function isSupportedCurrency(
+  currencyCode: string,
+): currencyCode is SupportedCurrency {
+  return supportedCurrencies.includes(currencyCode as SupportedCurrency);
+}
+
+export function validateCurrencyCode(currencyCode: string): SupportedCurrency {
+  if (!isSupportedCurrency(currencyCode)) {
+    // Try uppercasing the code
+    if (isSupportedCurrency(currencyCode.toUpperCase())) {
+      return currencyCode.toUpperCase() as SupportedCurrency;
+    }
+
+    throw new MedusaError(
+      MedusaErrorTypes.INVALID_ARGUMENT,
+      `Unsupported currency code provided to Paystack Paystack Payment Provider: ${currencyCode}`,
+    );
+  }
+
+  return currencyCode as SupportedCurrency;
+}

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -16,6 +16,7 @@
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,
+    "noImplicitAny": true,
     "allowJs": true,
     "skipLibCheck": true,
     "downlevelIteration": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,6 @@ importers:
       '@medusajs/utils':
         specifier: ^1.9.4
         version: 1.9.4
-      '@paralleldrive/cuid2':
-        specifier: ^2.2.1
-        version: 2.2.1
-      paystack-api:
-        specifier: ^2.0.6
-        version: 2.0.6
     devDependencies:
       '@medusajs/medusa':
         specifier: ^1.13.0
@@ -1250,11 +1244,6 @@ packages:
     dev: true
     optional: true
 
-  /@noble/hashes@1.3.1:
-    resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}
-    engines: {node: '>= 16'}
-    dev: false
-
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1426,12 +1415,6 @@ packages:
     engines: {node: '>=8.0.0'}
     deprecated: Deprecated in favor of @oclif/core
     dev: true
-
-  /@paralleldrive/cuid2@2.2.1:
-    resolution: {integrity: sha512-GJhHYlMhyT2gWemDL7BGMWfTNhspJKkikLKh9wAy3z4GTTINvTYALkUd+eGQK7aLeVkVzPuSA0VCT3H5eEWbbw==}
-    dependencies:
-      '@noble/hashes': 1.3.1
-    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1699,6 +1682,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+    dev: true
 
   /ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -1816,24 +1800,9 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: false
-
-  /assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
-    dev: false
-
   /async@3.2.4:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
     dev: true
-
-  /asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
   /awilix@8.0.1:
     resolution: {integrity: sha512-zDSp4R204scvQIDb2GMoWigzXemn0+3AKKIAt543T9v2h7lmoypvkmcx1W/Jet/nm27R1N1AsqrsYVviAR9KrA==}
@@ -1841,14 +1810,6 @@ packages:
     dependencies:
       camel-case: 4.1.2
       fast-glob: 3.2.12
-
-  /aws-sign2@0.7.0:
-    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
-    dev: false
-
-  /aws4@1.11.0:
-    resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
-    dev: false
 
   /axios-retry@3.6.0:
     resolution: {integrity: sha512-jtH4qWTKZ2a17dH6tjq52Y1ssNV0lKge6/Z9Lw67s9Wt01nGTg4hg7/LJBGYfDci44NTANJQlCPHPOT/TSFm9w==}
@@ -1951,12 +1912,6 @@ packages:
       safe-buffer: 5.1.2
     dev: true
 
-  /bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-    dependencies:
-      tweetnacl: 0.14.5
-    dev: false
-
   /better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -1976,10 +1931,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.2
     dev: true
-
-  /bluebird@3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
-    dev: false
 
   /body-parser@1.20.1:
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
@@ -2205,10 +2156,6 @@ packages:
       ansicolors: 0.3.2
       redeyed: 2.1.1
     dev: true
-
-  /caseless@0.12.0:
-    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
-    dev: false
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -2438,13 +2385,6 @@ packages:
       text-hex: 1.0.0
     dev: true
 
-  /combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
-
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -2555,6 +2495,7 @@ packages:
 
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+    dev: true
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -2632,13 +2573,6 @@ packages:
       csv-parse: 4.16.3
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
-    dev: false
-
-  /dashdash@1.14.1:
-    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      assert-plus: 1.0.0
     dev: false
 
   /date-fns@2.30.0:
@@ -2746,11 +2680,6 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
 
-  /delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    dev: false
-
   /denque@1.5.1:
     resolution: {integrity: sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==}
     engines: {node: '>=0.10'}
@@ -2834,13 +2763,6 @@ packages:
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
-
-  /ecc-jsbn@0.1.2:
-    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-    dev: false
 
   /ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -3290,10 +3212,6 @@ packages:
       - supports-color
     dev: true
 
-  /extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-    dev: false
-
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
     dev: false
@@ -3311,13 +3229,9 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /extsprintf@1.3.0:
-    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
-    engines: {'0': node >=0.6.0}
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
 
   /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
@@ -3331,6 +3245,7 @@ packages:
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: true
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
@@ -3457,19 +3372,6 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /forever-agent@0.6.1:
-    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
-    dev: false
-
-  /form-data@2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: false
-
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3583,12 +3485,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.1.3
 
-  /getpass@0.1.7:
-    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-    dependencies:
-      assert-plus: 1.0.0
-    dev: false
-
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3695,20 +3591,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: true
 
-  /har-schema@2.0.0:
-    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
-    engines: {node: '>=4'}
-    dev: false
-
-  /har-validator@5.1.5:
-    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
-    engines: {node: '>=6'}
-    deprecated: this library is no longer supported
-    dependencies:
-      ajv: 6.12.6
-      har-schema: 2.0.0
-    dev: false
-
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -3779,15 +3661,6 @@ packages:
       statuses: 2.0.1
       toidentifier: 1.0.1
     dev: true
-
-  /http-signature@1.2.0:
-    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.17.0
-    dev: false
 
   /human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
@@ -4092,6 +3965,7 @@ packages:
 
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+    dev: true
 
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -4136,10 +4010,6 @@ packages:
   /iso8601-duration@1.3.0:
     resolution: {integrity: sha512-K4CiUBzo3YeWk76FuET/dQPH03WE04R94feo5TSKQCXpoXQt9E4yx2CnY737QZnSAI3PI4WlKo/zfqizGx52QQ==}
     dev: true
-
-  /isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
-    dev: false
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -4631,10 +4501,6 @@ packages:
       argparse: 2.0.1
     dev: true
 
-  /jsbn@0.1.1:
-    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
-    dev: false
-
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -4650,18 +4516,11 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  /json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-    dev: false
+    dev: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
-
-  /json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-    dev: false
 
   /json5@1.0.1:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
@@ -4704,16 +4563,6 @@ packages:
       ms: 2.1.3
       semver: 7.5.4
     dev: true
-
-  /jsprim@1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
-    dev: false
 
   /jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
@@ -4818,6 +4667,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -5000,12 +4850,14 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: true
 
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -5069,10 +4921,6 @@ packages:
     resolution: {integrity: sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==}
     engines: {node: '>=16 || 14 >=14.17'}
     dev: true
-
-  /mitt@1.2.0:
-    resolution: {integrity: sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==}
-    dev: false
 
   /mixme@0.5.9:
     resolution: {integrity: sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==}
@@ -5234,10 +5082,6 @@ packages:
     dependencies:
       path-key: 3.1.1
     dev: true
-
-  /oauth-sign@0.9.0:
-    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
-    dev: false
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -5557,18 +5401,6 @@ packages:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
     dev: true
 
-  /paystack-api@2.0.6:
-    resolution: {integrity: sha512-KkTkyjQOAm9MxX17Tr4DqdINqYPtCWEzmbvriYna8L6/Q/NGvOAgHo4JzrVBRFsZGTUHDw9Q3CummT4itCl+OQ==}
-    dependencies:
-      mitt: 1.2.0
-      request: 2.88.2
-      request-promise: 4.2.6(request@2.88.2)
-    dev: false
-
-  /performance-now@2.1.0:
-    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
-    dev: false
-
   /pg-cloudflare@1.1.1:
     resolution: {integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==}
     requiresBuild: true
@@ -5765,10 +5597,6 @@ packages:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: false
 
-  /psl@1.9.0:
-    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
-    dev: false
-
   /pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
@@ -5779,6 +5607,7 @@ packages:
   /punycode@2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
+    dev: true
 
   /pure-rand@6.0.2:
     resolution: {integrity: sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==}
@@ -5797,11 +5626,6 @@ packages:
     dependencies:
       side-channel: 1.0.4
     dev: true
-
-  /qs@6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
-    engines: {node: '>=0.6'}
-    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6010,57 +5834,6 @@ packages:
       is_js: 0.9.0
     dev: true
 
-  /request-promise-core@1.1.4(request@2.88.2):
-    resolution: {integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      request: ^2.34
-    dependencies:
-      lodash: 4.17.21
-      request: 2.88.2
-    dev: false
-
-  /request-promise@4.2.6(request@2.88.2):
-    resolution: {integrity: sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==}
-    engines: {node: '>=0.10.0'}
-    deprecated: request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
-    peerDependencies:
-      request: ^2.34
-    dependencies:
-      bluebird: 3.7.2
-      request: 2.88.2
-      request-promise-core: 1.1.4(request@2.88.2)
-      stealthy-require: 1.1.1
-      tough-cookie: 2.5.0
-    dev: false
-
-  /request@2.88.2:
-    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
-    engines: {node: '>= 6'}
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.11.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.3
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-    dev: false
-
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6152,6 +5925,7 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -6372,22 +6146,6 @@ packages:
     resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
     dev: true
 
-  /sshpk@1.17.0:
-    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
-    dev: false
-
   /stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
     dev: true
@@ -6407,11 +6165,6 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
     dev: true
-
-  /stealthy-require@1.1.1:
-    resolution: {integrity: sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
@@ -6620,14 +6373,6 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
-  /tough-cookie@2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      psl: 1.9.0
-      punycode: 2.1.1
-    dev: false
-
   /trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
@@ -6716,12 +6461,6 @@ packages:
       yargs: 17.7.2
     dev: false
 
-  /tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
   /turbo-darwin-64@1.10.12:
     resolution: {integrity: sha512-vmDfGVPl5/aFenAbOj3eOx3ePNcWVUyZwYr7taRl0ZBbmv2TzjRiFotO4vrKCiTVnbqjQqAFQWY2ugbqCI1kOQ==}
     cpu: [x64]
@@ -6781,10 +6520,6 @@ packages:
       turbo-linux-arm64: 1.10.12
       turbo-windows-64: 1.10.12
       turbo-windows-arm64: 1.10.12
-    dev: false
-
-  /tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: false
 
   /type-check@0.4.0:
@@ -6982,6 +6717,7 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
+    dev: true
 
   /url-parse-lax@3.0.0:
     resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
@@ -6998,12 +6734,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
     dev: true
-
-  /uuid@3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -7046,15 +6776,6 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
     dev: true
-
-  /verror@1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
-    engines: {'0': node >=0.6.0}
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
-    dev: false
 
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}


### PR DESCRIPTION
Removes outdated Paystack API wrapper package we were using prior with a simpler helper class.

Also changes how we generate references. Transactions are initialized with Paystack and the returned reference used instead of an arbitrary cuid.

Closes #21 