### PR TITLE
Automatically capture orders

### DIFF
--- a/.changeset/perfect-pants-attack.md
+++ b/.changeset/perfect-pants-attack.md
@@ -1,0 +1,5 @@
+---
+"medusa-payment-paystack": minor
+---
+
+Payments are now automatically marked as captured. You do not have to go into the admin dashboard after every order to mark the payment as captured.

--- a/packages/plugin/src/subscribers/orderCapturer.ts
+++ b/packages/plugin/src/subscribers/orderCapturer.ts
@@ -1,0 +1,53 @@
+import { EventBusService, OrderService, CartService } from "@medusajs/medusa";
+
+type InjectedDependencies = {
+  eventBusService: EventBusService;
+  orderService: OrderService;
+  cartService: CartService;
+};
+
+type OrderPlacedData = {
+  id: string;
+};
+
+function isOrderPlacedData(data: unknown): data is OrderPlacedData {
+  return typeof data === "object" && data !== null && "id" in data;
+}
+
+class PaystackOrderCapturer {
+  eventBusService: EventBusService;
+  orderService: OrderService;
+
+  constructor(container: InjectedDependencies) {
+    this.eventBusService = container.eventBusService;
+    this.orderService = container.orderService;
+
+    this.eventBusService.subscribe("order.placed", this.handleOrder);
+  }
+
+  handleOrder = async (data: unknown) => {
+    try {
+      if (!isOrderPlacedData(data)) {
+        return;
+      }
+
+      const order = await this.orderService.retrieve(data.id, {
+        relations: ["payments"],
+      });
+      if (!order) return;
+
+      // Check if the order was paid for with Paystack
+      const isPaidForWithPaystack = order.payments?.some(
+        p => p.provider_id === "paystack",
+      );
+      if (!isPaidForWithPaystack) return;
+
+      // Capture the payment
+      await this.orderService.capturePayment(order.id);
+    } catch (error) {
+      console.error("Error capturing Paystack order:", error);
+    }
+  };
+}
+
+export default PaystackOrderCapturer;


### PR DESCRIPTION
# Overview
Closes #31.

Adds a subscriber that listens for new orders, confirms they were paid for with Paystack and then marks them as captured. 