### PR TITLE
Add support for more currencies

### DIFF
--- a/.changeset/brown-teachers-argue.md
+++ b/.changeset/brown-teachers-argue.md
@@ -1,0 +1,6 @@
+---
+"medusa-payment-paystack": patch
+---
+
+Removes hardcoded currency restrictions
+Improves logging of Paystack API errors

--- a/packages/plugin/src/lib/paystack.ts
+++ b/packages/plugin/src/lib/paystack.ts
@@ -1,7 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 
-import { SupportedCurrency } from "../utils/currencyCode";
-
 const PAYSTACK_API_PATH = "https://api.paystack.co";
 
 type HTTPMethod =
@@ -61,7 +59,11 @@ export default class Paystack {
       const res = await this.axiosInstance(options);
       return res.data;
     } catch (error) {
-      throw "Error from Paystack API: " + error.message;
+      if (axios.isAxiosError(error)) {
+        throw `Error from Paystack API with status code ${error.response?.status}: ${error.response?.data?.message}`;
+      }
+
+      throw error;
     }
   }
 
@@ -98,7 +100,7 @@ export default class Paystack {
     }: {
       amount: number;
       email?: string;
-      currency?: SupportedCurrency;
+      currency?: string;
       reference?: string;
     }) =>
       this.requestPaystackAPI<

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -10,7 +10,7 @@ import {
   CartService,
 } from "@medusajs/medusa";
 import { MedusaError, MedusaErrorTypes } from "@medusajs/utils";
-import { validateCurrencyCode } from "../utils/currencyCode";
+import { formatCurrencyCode } from "../utils/currencyCode";
 
 export interface PaystackPaymentProcessorConfig {
   /**
@@ -94,7 +94,7 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
 
     const { amount, email, currency_code } = context;
 
-    const validatedCurrencyCode = validateCurrencyCode(currency_code);
+    const validatedCurrencyCode = formatCurrencyCode(currency_code);
 
     const { data, status, message } =
       await this.paystack.transaction.initialize({

--- a/packages/plugin/src/utils/currencyCode.ts
+++ b/packages/plugin/src/utils/currencyCode.ts
@@ -1,27 +1,6 @@
-import { MedusaError, MedusaErrorTypes } from "@medusajs/utils";
+export function formatCurrencyCode(currencyCode: string) {
+  // Uppercase the currency code
+  const formattedCurrencyCode = currencyCode.toUpperCase();
 
-export const supportedCurrencies = ["NGN", "GHS", "ZAR", "USD"] as const;
-
-export type SupportedCurrency = (typeof supportedCurrencies)[number];
-
-export function isSupportedCurrency(
-  currencyCode: string,
-): currencyCode is SupportedCurrency {
-  return supportedCurrencies.includes(currencyCode as SupportedCurrency);
-}
-
-export function validateCurrencyCode(currencyCode: string): SupportedCurrency {
-  if (!isSupportedCurrency(currencyCode)) {
-    // Try uppercasing the code
-    if (isSupportedCurrency(currencyCode.toUpperCase())) {
-      return currencyCode.toUpperCase() as SupportedCurrency;
-    }
-
-    throw new MedusaError(
-      MedusaErrorTypes.INVALID_ARGUMENT,
-      `Unsupported currency code provided to Paystack Paystack Payment Provider: ${currencyCode}`,
-    );
-  }
-
-  return currencyCode as SupportedCurrency;
+  return formattedCurrencyCode;
 }


### PR DESCRIPTION
# Changes
- Removes hardcoded currency restrictions. 
Paystack has added support for more countries than it did before. Instead of keeping this in sync we'll defer currency validation to their API. Along with the improved error logging, store owners using the plugin can tell from the error returned the currency used is either not supported by Paystack or not enabled on their account. 

- Improves logging of Paystack API errors