### PR TITLE
Improve Paystack error handling

### DIFF
--- a/.changeset/shaggy-shirts-film.md
+++ b/.changeset/shaggy-shirts-film.md
@@ -1,0 +1,5 @@
+---
+"medusa-payment-paystack": patch
+---
+
+Adds support for automatically retrying network and 5xx errors in requests sent to Paystack.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,4 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      - dependency-name: "medusa-payment-paystack" # Keep plugin up to date
+      - dependency-name: "medusa-payment-paystack" # Keep plugin dep up to date

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/plugin" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/packages/plugin"
     versioning-strategy: increase
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/backend"
+    versioning-strategy: increase
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "medusa-payment-paystack" # Keep plugin up to date

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ yarn add medusa-payment-paystack
 
 ### Configure the Paystack Plugin
 
-Next, you need to add configurations for your paystack plugin.
+Next, you need to enable the plugin in your Medusa server.
 
-In `medusa-config.js` add the following at the end of the `plugins` array:
+In `medusa-config.js` add the following to the `plugins` array:
 
 ```js
 const plugins = [
@@ -44,6 +44,8 @@ const plugins = [
   },
 ];
 ```
+
+The full list of configuration options you can pass to the plugin can be found in [Config](#configuration)
 
 ## Admin Setup
 
@@ -111,7 +113,16 @@ You can refund captured payments made with Paystack from the Admin dashboard.
 
 `medusa-payment-paystack` handles refunding the given amount using Paystack and marks the order in Medusa as refunded.
 
+# Configuration
+
+| Name            | Type      | Default     | Description                                                                                   |
+| --------------- | --------- | ----------- | --------------------------------------------------------------------------------------------- |
+| secret_key      | `string`  | `undefined` | Your Paystack secret key                                                                      |
+| disable_retries | `boolean` | `false`     | Disable retries for 5xx and failed idempotent requests to Paystack                            |
+| debug           | `boolean` | `false`     | Enable debug mode for the plugin. If true, helpful debug information is logged to the console |
+
 # Demo
+
 Try out the demo here: [Medusa store with Paystack Integration](https://storefront-production-ae6c.up.railway.app/)
 
 ![Demo video](https://user-images.githubusercontent.com/87580113/211937892-d1a34735-78a5-451d-83f8-bc23185dd8ef.png)

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@medusajs/utils": "^1.9.4",
-    "axios": "^1.6.3"
+    "axios": "^1.6.3",
+    "axios-retry": "^4.0.0"
   },
   "devDependencies": {
     "@medusajs/medusa": "^1.16.1",
@@ -27,6 +28,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.1.2",
     "jest": "^29.7.0",
+    "msw": "^2.2.4",
     "prettier": "^3.1.0",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.1",

--- a/packages/plugin/src/lib/__mocks__/paystack.ts
+++ b/packages/plugin/src/lib/__mocks__/paystack.ts
@@ -1,94 +1,137 @@
-export const PaystackProviderServiceMock = {
-  transaction: {
-    verify: jest.fn().mockImplementation(({ reference }) => {
-      switch (reference) {
-        case "123-failed":
-          return Promise.resolve({
-            data: {
-              status: "failed",
-              id: "123",
-            },
-          });
-        case "123-passed":
-          return Promise.resolve({
-            data: {
-              status: "success",
-              id: "123",
-              amount: 2000,
-              currency: "GHS",
-            },
-          });
-        case "123-false":
-          return Promise.resolve({
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { PAYSTACK_API_PATH } from "../paystack";
+
+const handlers = [
+  // Transaction verification
+  http.get(`${PAYSTACK_API_PATH}/transaction/verify/:reference`, req => {
+    const { reference } = req.params;
+
+    switch (reference) {
+      case "123-failed":
+        return HttpResponse.json({
+          status: false,
+          message: "Verification failed",
+          data: {
+            status: "failed",
+            id: "123",
+          },
+        });
+
+      case "123-passed":
+        return HttpResponse.json({
+          status: true,
+          message: "Verification successful",
+          data: {
+            status: "success",
+            id: "123",
+            amount: 2000,
+            currency: "GHS",
+          },
+        });
+
+      case "123-false":
+        return HttpResponse.json({
+          status: false,
+          message: "Verification returned false status",
+          data: {
+            status: "failed",
+            id: "123",
+          },
+        });
+
+      case "123-throw": {
+        return HttpResponse.json(
+          {
             status: false,
-            data: {
-              status: "failed",
-              id: "123",
-            },
-          });
-        case "123-throw":
-          return Promise.reject(new Error("Paystack error"));
-        default:
-          return Promise.resolve({
-            data: {
-              status: "pending",
-              id: "123",
-            },
-          });
+            message: "Paystack error",
+          },
+          {
+            // @ts-expect-error
+            status: 400,
+          },
+        );
       }
-    }),
 
-    initialize: jest.fn().mockImplementation(({ amount, email }) => {
-      return Promise.resolve({
-        data: {
-          reference: "ref-" + Math.random() * 1000,
-          authorization_url: "https://paystack.com/123",
-        },
-      });
-    }),
+      default:
+        return HttpResponse.json({
+          status: true,
+          message: "Verification status pending",
+          data: {
+            status: "pending",
+            id: "123",
+          },
+        });
+    }
+  }),
 
-    get: jest.fn().mockImplementation(({ id }) => {
-      switch (id) {
-        case "123-success":
-          return Promise.resolve({
-            data: {
-              status: "success",
-              paystackTxId: id,
-              paystackTxData: {},
-            },
-          });
+  // Initialize transaction
+  http.post(`${PAYSTACK_API_PATH}/transaction/initialize`, () => {
+    return HttpResponse.json({
+      status: true,
+      message: "Transaction initialized",
+      data: {
+        reference: `ref-${Math.random() * 1000}`,
+        authorization_url: "https://paystack.com/123",
+      },
+    });
+  }),
 
-        case "123-false":
-          return Promise.resolve({
-            status: false,
-            data: {
-              status: "failed",
-              paystackTxId: id,
-              paystackTxData: {},
-            },
-          });
+  // Get transaction
+  http.get(`${PAYSTACK_API_PATH}/transaction/:id`, req => {
+    const { id } = req.params;
 
-        default:
-          return Promise.resolve({
-            data: {
-              status: "failed",
-              paystackTxId: id,
-              paystackTxData: {},
-            },
-          });
-      }
-    }),
-  },
+    switch (id) {
+      case "123-success":
+        return HttpResponse.json({
+          status: true,
+          message: "Transaction successful",
+          data: {
+            status: "success",
+            id: "123",
+            amount: 1000,
+            currency: "NGN",
+          },
+        });
+      case "123-false":
+        return HttpResponse.json({
+          status: false,
+          message: "Transaction failure",
+          data: {
+            status: "failed",
+            id: "123",
+          },
+        });
+      default:
+        return HttpResponse.json({
+          status: false,
+          message: "Transaction not found",
+          data: {
+            status: "failed",
+            id: id,
+          },
+        });
+    }
+  }),
 
-  refund: {
-    create: jest.fn().mockImplementation(({ transaction, amount }) =>
-      Promise.resolve({
+  // Create refund
+  http.post(`${PAYSTACK_API_PATH}/refund`, async req => {
+    const { transaction, amount } = (await req.request.json()) as {
+      transaction: string;
+      amount: number;
+    };
+
+    return HttpResponse.json({
+      status: true,
+      message: "Refund created",
+      data: {
+        id: Math.floor(Math.random() * 10000),
+        status: "success",
         transaction,
         amount,
-        paystackTxData: {},
-      }),
-    ),
-  },
-};
+      },
+    });
+  }),
+];
 
-export default jest.fn(() => PaystackProviderServiceMock);
+export const paystackMockServer = setupServer(...handlers);

--- a/packages/plugin/src/lib/paystack.ts
+++ b/packages/plugin/src/lib/paystack.ts
@@ -33,7 +33,7 @@ export interface PaystackTransactionAuthorisation {
 }
 
 export interface PaystackWrapperOptions {
-  disableRetries?: boolean;
+  disable_retries?: boolean;
 }
 
 export default class Paystack {
@@ -51,7 +51,7 @@ export default class Paystack {
       },
     });
 
-    if (options?.disableRetries !== true) {
+    if (options?.disable_retries !== true) {
       axiosRetry(this.axiosInstance, {
         retries: 3,
         // Enables retries on network errors, idempotent http methods, and 5xx errors

--- a/packages/plugin/src/lib/paystack.ts
+++ b/packages/plugin/src/lib/paystack.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import axiosRetry from "axios-retry";
 
-const PAYSTACK_API_PATH = "https://api.paystack.co";
+export const PAYSTACK_API_PATH = "https://api.paystack.co";
 
 type HTTPMethod =
   | "GET"
@@ -31,12 +32,16 @@ export interface PaystackTransactionAuthorisation {
   access_code: string;
 }
 
+export interface PaystackWrapperOptions {
+  disableRetries?: boolean;
+}
+
 export default class Paystack {
   apiKey: string;
 
   protected readonly axiosInstance: AxiosInstance;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, options?: PaystackWrapperOptions) {
     this.apiKey = apiKey;
     this.axiosInstance = axios.create({
       baseURL: PAYSTACK_API_PATH,
@@ -45,6 +50,16 @@ export default class Paystack {
         "Content-Type": "application/json",
       },
     });
+
+    if (options?.disableRetries !== true) {
+      axiosRetry(this.axiosInstance, {
+        retries: 3,
+        // Enables retries on network errors, idempotent http methods, and 5xx errors
+        retryCondition: axiosRetry.isNetworkOrIdempotentRequestError,
+        // Exponential backoff with jitter
+        retryDelay: axiosRetry.exponentialDelay,
+      });
+    }
   }
 
   protected async requestPaystackAPI<T>(request: Request): Promise<T> {

--- a/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
@@ -6,6 +6,7 @@ import {
 
 import PaystackPaymentProcessor from "../paystack-payment-processor";
 import { CartServiceMock } from "../../__mocks__/cart";
+import { paystackMockServer } from "../../lib/__mocks__/paystack-msw";
 
 interface ProviderServiceMockOptions {
   secretKey?: string | undefined;
@@ -47,7 +48,15 @@ const demoSessionContext = {
   paymentSessionData: {},
 } satisfies PaymentProcessorContext;
 
-jest.mock("../../lib/paystack");
+paystackMockServer.listen();
+
+afterEach(() => {
+  paystackMockServer.resetHandlers();
+});
+
+afterAll(() => {
+  paystackMockServer.close();
+});
 
 describe("Provider Service Initialization", () => {
   it("initializes the provider service", () => {
@@ -302,4 +311,10 @@ describe("deletePayment", () => {
       paystackTxId: "123-delete",
     });
   });
+});
+
+describe("Paystack 5xx handling", () => {
+  it("retries on 5xx errors from Paystack", () => {});
+
+  it("exits with an error state on 3 failed retries", () => {});
 });

--- a/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
@@ -327,10 +327,10 @@ describe("Retriable error handling", () => {
     expect(payment.status).toEqual(PaymentSessionStatus.AUTHORIZED);
   });
 
-  it("does not retry if disableRetries is true", async () => {
+  it("does not retry if disable_retries is true", async () => {
     const service = createPaystackProviderService({
       secret_key: "sk_test_123",
-      disableRetries: true,
+      disable_retries: true,
     });
 
     // We receive a PaymentProcessorError

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -25,6 +25,15 @@ export interface PaystackPaymentProcessorConfig {
   secret_key: string;
 
   /**
+   * Disable retries for 5xx and failed idempotent requests to Paystack
+   *
+   * Generally, you should not disable retries, these errors are usually temporary
+   * but it can be useful for debugging
+   * @default false
+   */
+  disableRetries?: boolean;
+
+  /**
    * Debug mode
    * If true, logs helpful debug information to the console
    * Logs are prefixed with "PS_P_Debug"
@@ -54,7 +63,9 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
     }
 
     this.configuration = options;
-    this.paystack = new Paystack(this.configuration.secret_key);
+    this.paystack = new Paystack(this.configuration.secret_key, {
+      disableRetries: options.disableRetries,
+    });
     this.debug = Boolean(options.debug);
 
     // @ts-expect-error - Container is just an object - https://docs.medusajs.com/development/fundamentals/dependency-injection#in-classes

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -31,7 +31,7 @@ export interface PaystackPaymentProcessorConfig {
    * but it can be useful for debugging
    * @default false
    */
-  disableRetries?: boolean;
+  disable_retries?: boolean;
 
   /**
    * Debug mode
@@ -64,7 +64,7 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
 
     this.configuration = options;
     this.paystack = new Paystack(this.configuration.secret_key, {
-      disableRetries: options.disableRetries,
+      disable_retries: options.disable_retries,
     });
     this.debug = Boolean(options.debug);
 

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -25,7 +25,7 @@ export interface PaystackPaymentProcessorConfig {
   secret_key: string;
 
   /**
-   * Disable retries for 5xx and failed idempotent requests to Paystack
+   * Disable retries on network errors and 5xx errors on idempotent requests to Paystack
    *
    * Generally, you should not disable retries, these errors are usually temporary
    * but it can be useful for debugging
@@ -54,6 +54,48 @@ class PaystackPaymentProcessor extends AbstractPaymentProcessor {
     options: PaystackPaymentProcessorConfig,
   ) {
     super(container);
+
+    const { setupServer } = require("msw/node");
+    const { http, HttpResponse } = require("msw");
+
+    let retryCount = 0;
+
+    const mswServer = setupServer(
+      http.post("https://api.paystack.co/refund", () => {
+        // Respond with an error for the first 3 requests
+        if (retryCount <= 2) {
+          retryCount++;
+          console.log("Retrying", retryCount);
+          return HttpResponse.json(
+            {
+              status: false,
+              message: "Paystack error",
+            },
+            {
+              status: 504,
+            },
+          );
+        }
+
+        // Respond with success on the 4th attempt
+        return HttpResponse.json({
+          status: true,
+          message: "Verification successful",
+          data: {
+            status: "success",
+            id: "123",
+            amount: 2000,
+            currency: "GHS",
+          },
+        });
+      }),
+    );
+
+    mswServer.listen();
+
+    mswServer.events.on("request:start", ({ request }: { request: any }) => {
+      console.log("MSW intercepted:", request.method, request.url);
+    });
 
     if (!options.secret_key) {
       throw new MedusaError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       axios:
         specifier: ^1.6.3
         version: 1.6.5
+      axios-retry:
+        specifier: ^4.0.0
+        version: 4.0.0(axios@1.6.5)
     devDependencies:
       '@medusajs/medusa':
         specifier: ^1.16.1
@@ -57,6 +60,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@16.18.39)
+      msw:
+        specifier: ^2.2.4
+        version: 2.2.4(typescript@5.3.3)
       prettier:
         specifier: ^3.1.0
         version: 3.2.1
@@ -507,6 +513,18 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
+  /@bundled-es-modules/cookie@2.0.0:
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+    dependencies:
+      cookie: 0.5.0
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
+    dev: true
+
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
     dependencies:
@@ -779,6 +797,39 @@ packages:
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@inquirer/confirm@3.1.0:
+    resolution: {integrity: sha512-nH5mxoTEoqk6WpoBz80GMpDSm9jH5V9AF8n+JZAZfMzd9gHeEG9w1o3KawPRR72lfzpP+QxBHLkOKLEApwhDiQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 7.1.0
+      '@inquirer/type': 1.2.1
+    dev: true
+
+  /@inquirer/core@7.1.0:
+    resolution: {integrity: sha512-FRCiDiU54XHt5B/D8hX4twwZuzSP244ANHbu3R7CAsJfiv1dUOz24ePBgCZjygEjDUi6BWIJuk4eWLKJ7LATUw==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/type': 1.2.1
+      '@types/mute-stream': 0.0.4
+      '@types/node': 20.11.28
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      figures: 3.2.0
+      mute-stream: 1.0.0
+      run-async: 3.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+    dev: true
+
+  /@inquirer/type@1.2.1:
+    resolution: {integrity: sha512-xwMfkPAxeo8Ji/IxfUSqzRi0/+F2GIqJmpc5/thelgMGsjNZcjDDRBO9TLXT1s/hdx/mK5QbVIvgoLIFgXhTMQ==}
+    engines: {node: '>=18'}
     dev: true
 
   /@ioredis/as-callback@3.0.0:
@@ -1825,6 +1876,23 @@ packages:
     dev: true
     optional: true
 
+  /@mswjs/cookies@1.1.0:
+    resolution: {integrity: sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@mswjs/interceptors@0.25.16:
+    resolution: {integrity: sha512-8QC8JyKztvoGAdPgyZy49c9vSHHAZjHagwl4RY9E8carULk8ym3iTaiawrT1YoLF/qb449h48f71XDPgkUSOUg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      strict-event-emitter: 0.5.1
+    dev: true
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2027,6 +2095,21 @@ packages:
     deprecated: Deprecated in favor of @oclif/core
     dev: true
 
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+    dev: true
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2108,6 +2191,10 @@ packages:
       '@babel/types': 7.22.19
     dev: true
 
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    dev: true
+
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
@@ -2170,12 +2257,24 @@ packages:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: false
 
+  /@types/mute-stream@0.0.4:
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+    dependencies:
+      '@types/node': 16.18.39
+    dev: true
+
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: false
 
   /@types/node@16.18.39:
     resolution: {integrity: sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==}
+
+  /@types/node@20.11.28:
+    resolution: {integrity: sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -2199,12 +2298,20 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
+  /@types/statuses@2.0.5:
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+    dev: true
+
   /@types/triple-beam@1.3.2:
     resolution: {integrity: sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==}
     dev: true
 
   /@types/validator@13.11.1:
     resolution: {integrity: sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A==}
+    dev: true
+
+  /@types/wrap-ansi@3.0.0:
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -2500,6 +2607,15 @@ packages:
       '@babel/runtime': 7.23.2
       is-retry-allowed: 2.2.0
     dev: true
+
+  /axios-retry@4.0.0(axios@1.6.5):
+    resolution: {integrity: sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==}
+    peerDependencies:
+      axios: 0.x || 1.x
+    dependencies:
+      axios: 1.6.5
+      is-retry-allowed: 2.2.0
+    dev: false
 
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
@@ -2953,6 +3069,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+    dev: true
+
   /cli-ux@5.6.7(@oclif/config@1.18.17):
     resolution: {integrity: sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==}
     engines: {node: '>=8.0.0'}
@@ -2991,6 +3112,11 @@ packages:
   /cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
+    dev: true
+
+  /cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
     dev: true
 
   /cliui@6.0.0:
@@ -4568,6 +4694,10 @@ packages:
     dependencies:
       function-bind: 1.1.2
 
+  /headers-polyfill@4.0.2:
+    resolution: {integrity: sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==}
+    dev: true
+
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: true
@@ -4863,6 +4993,10 @@ packages:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
 
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
+
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
@@ -4898,7 +5032,6 @@ packages:
   /is-retry-allowed@2.2.0:
     resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
     engines: {node: '>=10'}
-    dev: true
 
   /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
@@ -6269,6 +6402,37 @@ packages:
       msgpackr-extract: 3.0.2
     dev: true
 
+  /msw@2.2.4(typescript@5.3.3):
+    resolution: {integrity: sha512-jFRVA8megbf134fZsddsEuZZCe0O0NIaW3NssSya4ZJ7jODRUodKMFjVjphA+ckS9pPhIrE/ehTrgccShAKU2A==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.7.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@inquirer/confirm': 3.1.0
+      '@mswjs/cookies': 1.1.0
+      '@mswjs/interceptors': 0.25.16
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      chalk: 4.1.2
+      graphql: 16.8.1
+      headers-polyfill: 4.0.2
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.12.0
+      typescript: 5.3.3
+      yargs: 17.7.2
+    dev: true
+
   /multer@1.4.5-lts.1:
     resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==}
     engines: {node: '>= 6.0.0'}
@@ -6284,6 +6448,11 @@ packages:
 
   /mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+    dev: true
+
+  /mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
 
   /mz@2.7.0:
@@ -6512,6 +6681,10 @@ packages:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: false
 
+  /outvariant@1.4.2:
+    resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
+    dev: true
+
   /p-cancelable@1.1.0:
     resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==}
     engines: {node: '>=6'}
@@ -6696,6 +6869,10 @@ packages:
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: true
+
+  /path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
     dev: true
 
   /path-type@4.0.0:
@@ -7311,6 +7488,11 @@ packages:
     engines: {node: '>=0.12.0'}
     dev: true
 
+  /run-async@3.0.0:
+    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -7584,6 +7766,10 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: true
+
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
     dev: true
 
   /string-argv@0.3.2:
@@ -8012,6 +8198,11 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
+  /type-fest@4.12.0:
+    resolution: {integrity: sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==}
+    engines: {node: '>=16'}
+    dev: true
+
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -8179,6 +8370,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
 
   /unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}


### PR DESCRIPTION
# Overview
Adds support for automatically retrying network and 5xx errors in requests sent to Paystack. Will help mitigate #94 

# Other Changes
- Replaces Paystack request Jest mocks with MSW mocks