### PR TITLE
Initiate Payment Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Refer to [this documentation in the user guide](https://docs.medusajs.com/v1/use
 
 Follow Medusa's [Storefront Development Checkout Flow](https://docs.medusajs.com/resources/storefront-development/checkout/payment) guide using `pp_paystack` as the `provider_id` to add Paystack to your checkout flow.
 
-### Email in `initiatePaymentSession` context
+### Email in `initiatePaymentSession` data
 
 Paystack requires the customer's email address to create a transaction.
 
@@ -91,7 +91,7 @@ If your storefront does not collect customer email addresses, you can provide a 
 ```ts
 await initiatePaymentSession(cart, {
   provider_id: selectedPaymentMethod,
-  context: {
+  data: {
     email: cart.email,
   },
 });

--- a/examples/storefront/src/lib/data/cart.ts
+++ b/examples/storefront/src/lib/data/cart.ts
@@ -220,7 +220,7 @@ export async function initiatePaymentSession(
   cart: HttpTypes.StoreCart,
   data: {
     provider_id: string
-    context?: Record<string, unknown>
+    data?: Record<string, unknown>
   }
 ) {
   const headers = {

--- a/examples/storefront/src/modules/checkout/components/payment/index.tsx
+++ b/examples/storefront/src/modules/checkout/components/payment/index.tsx
@@ -90,7 +90,7 @@ const Payment = ({
       if (!activeSession) {
         await initiatePaymentSession(cart, {
           provider_id: selectedPaymentMethod,
-          context: {
+          data: {
             email: cart.email,
           },
         })

--- a/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/__tests__/paystack-payment-processor.ts
@@ -43,7 +43,7 @@ function checkForPaymentProcessorError<T>(response: T | PaymentProviderError) {
 const demoCreatePaymentProviderSession = {
   amount: 100,
   currency_code: "GHS",
-  context: {
+  data: {
     email: "andrew@a11rew.dev",
   },
 } satisfies CreatePaymentProviderSession;
@@ -83,7 +83,7 @@ describe("initiatePayment", () => {
       await service.initiatePayment({
         amount: 100,
         currency_code: "GHS",
-        context: {
+        data: {
           email: "andrew@a11rew.dev",
         },
       }),
@@ -99,7 +99,7 @@ describe("initiatePayment", () => {
     const response = await service.initiatePayment({
       amount: 100,
       currency_code: "GHS",
-      context: {},
+      data: {},
     });
 
     expect(isPaymentProviderError(response)).toBeTruthy();
@@ -113,7 +113,7 @@ describe("initiatePayment", () => {
     const response = await service.initiatePayment({
       amount: "invalid-amount",
       currency_code: "GHS",
-      context: {
+      data: {
         email: "andrew@a11rew.dev",
       },
     });

--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -96,8 +96,8 @@ class PaystackPaymentProcessor extends AbstractPaymentProvider {
       );
     }
 
-    const { context, amount, currency_code } = initiatePaymentData;
-    const { email, session_id } = context;
+    const { data, amount, currency_code } = initiatePaymentData;
+    const { email, session_id } = data;
 
     const validatedCurrencyCode = formatCurrencyCode(currency_code);
 


### PR DESCRIPTION
context not defined in payment Initialization request. Context changed to data.
This fixes issues with initiating payment from the backend and verification